### PR TITLE
fix(scripts): added prepare back and increment version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-conditional-flow",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "files": [
     "lib"
   ],
@@ -26,6 +26,7 @@
     "lint": "eslint --ignore-path .eslintignore --ext js,jsx,snap .",
     "posttest": "npm run lint",
     "test": "jest",
+    "prepare": "npm run build",
     "githook:pre-commit": "npm run test",
     "githook:commit-msg": "commitlint --edit $GIT_PARAMS"
   },


### PR DESCRIPTION
There was an issue after the "prepare" script was taken away where upon `npm i` the `lib` folder was not being built. This PR adds the "prepare" back to the package.json